### PR TITLE
Add CASCADE for foreign key relationships.

### DIFF
--- a/helper/postgres/postgres.go
+++ b/helper/postgres/postgres.go
@@ -23,5 +23,5 @@ func (Helper) GetTablesQuery() string {
 
 // TruncateTableCommand returns postgres command to truncate table
 func (Helper) TruncateTableCommand(table string) string {
-	return fmt.Sprintf("TRUNCATE TABLE %s", table)
+	return fmt.Sprintf("TRUNCATE TABLE %s CASCADE", table)
 }

--- a/helper/postgres/postgres_test.go
+++ b/helper/postgres/postgres_test.go
@@ -21,7 +21,7 @@ func TestTruncateTableCommand(t *testing.T) {
 	table := "users"
 	cmd := helper.TruncateTableCommand(table)
 
-	if cmd != "TRUNCATE TABLE users" {
+	if cmd != "TRUNCATE TABLE users CASCADE" {
 		t.Error("Wrong command")
 	}
 }

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -64,8 +64,9 @@ func setupPostgres() {
 
 	commands := []string{
 		"CREATE TABLE users(id serial primary key, name varchar)",
-		"CREATE TABLE customers(id serial primary key, name varchar)",
+		"CREATE TABLE customers(id serial primary key, user_id integer REFERENCES users)",
 		"INSERT INTO users(name) values ('UserA')",
+		"INSERT INTO customers(user_id) values (currval('users_id_seq'))",
 	}
 
 	for _, cmd := range commands {


### PR DESCRIPTION
DBCleaner seems to refuse to work when you have relationships in your database. Within PostgreSQL, appending `CASCADE` to the end of the `TRUNCATE` statement fixes it. At least in my use case.