### PR TITLE
reset autoincrement identity

### DIFF
--- a/engine/postgres.go
+++ b/engine/postgres.go
@@ -23,7 +23,7 @@ func NewPostgresEngine(dsn string) Engine {
 }
 
 func (p *Postgres) Truncate(table string) error {
-	cmd := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", table)
+	cmd := fmt.Sprintf("TRUNCATE TABLE %s RESTART IDENTITY CASCADE", table)
 
 	_, err := p.db.Exec(cmd)
 	return err

--- a/engine/postgres_test.go
+++ b/engine/postgres_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"database/sql"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -14,6 +15,11 @@ func TestPostgresTruncate(t *testing.T) {
 
 	t.Run("Truncate users table", func(t *testing.T) {
 		err := dbEngine.Truncate("users")
+		db, _ := sql.Open("postgres", dsn)
+		result, _ := db.Exec("select id from users")
+		actual, _ := result.LastInsertId()
+
+		assert.Equal(int64(0), actual)
 		assert.NoError(err)
 	})
 

--- a/engine/sqlite.go
+++ b/engine/sqlite.go
@@ -28,7 +28,14 @@ func (sqlite *SQLite) Truncate(table string) error {
 	cmd := fmt.Sprintf("DELETE FROM %s", table)
 
 	_, err := sqlite.db.Exec(cmd)
-	return err
+	if err != nil {
+		return err
+	}
+
+	resetSequenceCMD := fmt.Sprintf("DELETE FROM SQLITE_SEQUENCE WHERE name=%s", table)
+	_, errCmd := sqlite.db.Exec(resetSequenceCMD)
+
+	return errCmd
 }
 
 func (sqlite *SQLite) Close() error {

--- a/engine/sqlite.go
+++ b/engine/sqlite.go
@@ -32,7 +32,7 @@ func (sqlite *SQLite) Truncate(table string) error {
 		return err
 	}
 
-	resetSequenceCMD := fmt.Sprintf("DELETE FROM SQLITE_SEQUENCE WHERE name=%s", table)
+	resetSequenceCMD := fmt.Sprintf(`DELETE FROM sqlite_sequence WHERE EXISTS(SELECT name FROM sqlite_sequence WHERE name = "%s");`, table)
 	_, errCmd := sqlite.db.Exec(resetSequenceCMD)
 
 	return errCmd

--- a/engine/sqlite_test.go
+++ b/engine/sqlite_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"database/sql"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -11,9 +12,14 @@ func TestSQLiteTruncate(t *testing.T) {
 	assert := assert.New(t)
 	dbFilePath := "../dbcleaner_test.db"
 	dbEngine := NewSqliteEngine(dbFilePath)
+	db, _ := sql.Open("sqlite3", "../dbcleaner_test.db")
 
 	t.Run("Truncate users table", func(t *testing.T) {
 		err := dbEngine.Truncate("users")
+		result, _ := db.Exec("select id from users")
+		actual, _ := result.LastInsertId()
+
+		assert.Equal(int64(0), actual)
 		assert.NoError(err)
 	})
 

--- a/fixtures/postgres_schema.sql
+++ b/fixtures/postgres_schema.sql
@@ -10,3 +10,5 @@ CREATE TABLE addresses (
   primary key (id),
   FOREIGN KEY (user_id) REFERENCES users(id)
 );
+
+INSERT INTO users (name) VALUES ("example");

--- a/fixtures/sqlite_schema.sql
+++ b/fixtures/sqlite_schema.sql
@@ -8,3 +8,5 @@ CREATE TABLE addresses (
   user_id INTEGER null,
   FOREIGN KEY (user_id) REFERENCES users(id)
 );
+
+INSERT INTO users (name) VALUES ("example");


### PR DESCRIPTION
* It's a good approach to reset identity (ID) if we truncate the table. 
* It's also the default behaviour of MySQL truncation.

This pull request is cover those two points above in PostgreSQL and SQLite